### PR TITLE
Fix on_missing Literal type

### DIFF
--- a/asl_tts_lib/config.py
+++ b/asl_tts_lib/config.py
@@ -16,7 +16,7 @@ class Config:
     cache_directory: Path = Path("/tmp/asl-tts-tools-cache")
 
     # Sound handling
-    on_missing: Literal["beep", "silence", "skip"] = "error"
+    on_missing: Literal["error", "beep", "skip"] = "error"
     beep_sound: str = "beep"
     silence_sound: str = "silence/1"
     max_phrase_words_for_filenames: int = 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+import unittest
+import sys
+from types import SimpleNamespace
+sys.modules.setdefault('yaml', SimpleNamespace(safe_load=lambda f: {}))
+from pathlib import Path
+from asl_tts_lib.config import Config
+
+class ConfigTests(unittest.TestCase):
+    def test_default_init(self):
+        cfg = Config()
+        self.assertEqual(cfg.on_missing, "error")
+        self.assertIsInstance(cfg.sounds_directory, Path)
+        self.assertIsInstance(cfg.custom_sounds_directory, Path)
+        self.assertIsInstance(cfg.cache_directory, Path)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- type `on_missing` as `Literal["error", "beep", "skip"]`
- add a minimal unittest for the Config dataclass

## Testing
- `python3 -m unittest discover -s tests -v`